### PR TITLE
Update EWS spray param descriptions

### DIFF
--- a/MailSniper.ps1
+++ b/MailSniper.ps1
@@ -1605,7 +1605,7 @@ function Invoke-PasswordSprayEWS{
 
     .PARAMETER UserList
 
-        List of usernames 1 per line to to attempt to password spray against.
+        List of usernames including domain (domain\username), 1 per line to to attempt to password spray against.
 
     .PARAMETER Password
 


### PR DESCRIPTION
Update ews 'usernames' for inclusion of domain string with usernames in file. Script fails without the domain prepended to the usernames.