### PR TITLE
Feature: Paging for Get-GlobalAddressList

### DIFF
--- a/MailSniper.ps1
+++ b/MailSniper.ps1
@@ -1452,7 +1452,7 @@ function Get-GlobalAddressList{
 
         Write-Output "[*] Now utilizing FindPeople to retrieve Global Address List"
 		
-		# setup variables for use in paging.
+	# setup variables for use in paging.
         $recordsFound = $true
         $start = $StartRow
         $maxRows = $MaxRows
@@ -1465,7 +1465,7 @@ function Get-GlobalAddressList{
             
 			if($FindPeopleResults.RawContent.IndexOf("""ResultSet"":[]") -gt -1)
             {
-				#if no results are returned, we've reached the end and can exit the loop.
+		#if no results are returned, we've reached the end and can exit the loop.
                 $recordsFound = $false
             }
 

--- a/MailSniper.ps1
+++ b/MailSniper.ps1
@@ -1316,11 +1316,11 @@ function Get-GlobalAddressList{
 
     [Parameter(Position = 5, Mandatory = $False)]
     [string]
-    $StartRow = "",
+    $StartRow = 0,
 
     [Parameter(Position = 6, Mandatory = $False)]
     [string]
-    $MaxRows = ""
+    $MaxRows = 5000
 
   )
     ## Choose to ignore any SSL Warning issues caused by Self Signed Certificates     


### PR DESCRIPTION
Problem: Get-GlobalAddressList makes only one request to the server to fetch records.  If the server has more records than the server is willing to serve, there is no way to fetch the remaining records.

Solution: Paging.  I've added two parameters to Get-GlobalAddressList, StartRow and MaxRows.  These two new parameters allow you to specify where in the list you want to start downloading from (StartRow) and how many records you want to download (MaxRows) per request.  The script will continue downloading records until there are no more records to download.