### PR TITLE
Improve error handling on AutoDiscoverUrl

### DIFF
--- a/MailSniper.ps1
+++ b/MailSniper.ps1
@@ -759,7 +759,24 @@ function Invoke-SelfSearch{
   else
   {
     ("[*] Autodiscovering email server for " + $Mailbox + "...")
-    $service.AutoDiscoverUrl($Mailbox, {$true})
+    try
+    {
+      $service.AutoDiscoverUrl($Mailbox, {$true})
+    }
+    catch [System.Management.Automation.MethodInvocationException]
+    {
+      $e = $_.Exception.InnerException
+      if ($e.GetType().Name -eq "AutodiscoverRemoteException")
+      {
+        [Microsoft.Exchange.WebServices.autodiscover.AutodiscoverRemoteException]$e = $e
+        # AutodiscoverRemoteException has an Error property which describes the error returned by the AutoDiscover service
+        # https://msdn.microsoft.com/en-us/library/microsoft.exchange.webservices.autodiscover.autodiscoverremoteexception.error%28v=exchg.80%29.aspx?f=255&MSPPError=-2147217396
+        Write-Output ("[!] AutodiscoverRemoteException: '" + $e.Error.Message + "'")
+        break
+      }
+      # Unfortunately, the other exception case, AutodiscoverLocalException does not have the Error property
+      # Therefore we do not have any interesting info to display
+    }
   }    
 
     if($OtherUserMailbox)
@@ -2821,7 +2838,24 @@ function Invoke-OpenInboxFinder{
   else
   {
     ("[*] Autodiscovering email server for " + $Mailbox + "...")
-    $service.AutoDiscoverUrl($Mailbox, {$true})
+    try
+    {
+      $service.AutoDiscoverUrl($Mailbox, {$true})
+    }
+    catch [System.Management.Automation.MethodInvocationException]
+    {
+      $e = $_.Exception.InnerException
+      if ($e.GetType().Name -eq "AutodiscoverRemoteException")
+      {
+        [Microsoft.Exchange.WebServices.autodiscover.AutodiscoverRemoteException]$e = $e
+        # AutodiscoverRemoteException has an Error property which describes the error returned by the AutoDiscover service
+        # https://msdn.microsoft.com/en-us/library/microsoft.exchange.webservices.autodiscover.autodiscoverremoteexception.error%28v=exchg.80%29.aspx?f=255&MSPPError=-2147217396
+        Write-Output ("[!] AutodiscoverRemoteException: '" + $e.Error.Message + "'")
+        break
+      }
+      # Unfortunately, the other exception case, AutodiscoverLocalException does not have the Error property
+      # Therefore we do not have any interesting info to display
+    }
   }    
     
     try


### PR DESCRIPTION
Display the inner exception details for AutodiscoverRemoteException
This happens if the first email address in the list isn't an existing email (as I recently encountered this situation).

Before, the script would simply advise to retry with valid credentials (which wasn't the issue).
Now, the script displays the error message that should be "Email address not found".