### PR TITLE
Force TLS 1.2

### DIFF
--- a/MailSniper.ps1
+++ b/MailSniper.ps1
@@ -1341,6 +1341,9 @@ function Get-GlobalAddressList{
 
     ## end code from http://poshcode.org/624
     $ErrorActionPreference = "Stop"
+    
+    ## Enforce TLS 1.2 to avoid SSL/TLS errors in the next Invoke-WebRequest calls
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
     try
     {


### PR DESCRIPTION
PowerShell uses TLS 1.0 by default in older versions, which doesn't work with some websites. Apparently Microsoft is [enforcing TLS 1.2](https://support.microsoft.com/en-us/help/4057306/preparing-for-tls-1-2-in-office-365) moving forward on their services.

This update also fixes #63