### PR TITLE
improve results of Invoke-DomainHarvestOWA and account for underscores in domain name

### DIFF
--- a/MailSniper.ps1
+++ b/MailSniper.ps1
@@ -2199,10 +2199,10 @@ function Invoke-DomainHarvestOWA {
                 {
                 $wwwheader = $($headers[$headerkey]) -split ',|\s'
                 $base64decoded = [System.Text.Encoding]::Unicode.GetString([System.Convert]::FromBase64String($wwwheader[1]))
-                $commasep = $base64decoded -replace '[^\x21-\x39\x41-\x5A\x61-\x7A]+', ','
+                $commasep = $base64decoded -replace '[^\x21-\x39\x41-\x5A\x61-\x7A\x5F]+', ','
                 $ntlmresparray = @()
                 $ntlmresparray = $commasep -split ','
-                Write-Host ("The domain appears to be: " + $ntlmresparray[7])
+                Write-Host ("The domain appears to be: " + $ntlmresparray[4] + " or " +$ntlmresparray[7])
                 }
 
             }
@@ -2226,10 +2226,10 @@ function Invoke-DomainHarvestOWA {
                         {
                         $wwwheader = $($headers[$headerkey]) -split ',|\s'
                         $base64decoded = [System.Text.Encoding]::Unicode.GetString([System.Convert]::FromBase64String($wwwheader[1]))
-                        $commasep = $base64decoded -replace '[^\x21-\x39\x41-\x5A\x61-\x7A]+', ','
+                        $commasep = $base64decoded -replace '[^\x21-\x39\x41-\x5A\x61-\x7A\x5F]+', ','
                         $ntlmresparray = @()
                         $ntlmresparray = $commasep -split ','
-                        Write-Host ("The domain appears to be: " + $ntlmresparray[7])
+                        Write-Host ("The domain appears to be: " + $ntlmresparray[4] + " or " +$ntlmresparray[7])
                         }
 
                     }


### PR DESCRIPTION
Output two likely domain names and modify regex to account for domain names containing underscores.

```
$base64decoded = [System.Text.Encoding]::Unicode.GetString([System.Convert]::FromBase64String($wwwheader[1]))
#Modify regex to match on underscores(x5F) to accomodate domain names like domain_name
$commasep = $base64decoded -replace '[^\x21-\x39\x41-\x5A\x61-\x7A\x5F]+', ','
$ntlmresparray = @()
$ntlmresparray = $commasep -split ','
#Include array index 4 as a viable domain name
Write-Host ("The domain appears to be: " + $ntlmresparray[4] + " or " +$ntlmresparray[7])
```